### PR TITLE
karma-nightmare - Configured Karma to use Nightmare instead of Chrome…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,5 @@ node_js:
  - '6.10.2'
 
 before_install:
- - export CHROME_BIN=/usr/bin/google-chrome
  - export DISPLAY=:99.0
  - sh -e /etc/init.d/xvfb start
- - sudo apt-get update
- - sudo apt-get install -y libappindicator1 fonts-liberation
- - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
- - sudo dpkg -i google-chrome*.deb

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -10,6 +10,7 @@ module.exports = function (config) {
       require('karma-chrome-launcher'),
       require('karma-jasmine-html-reporter'),
       require('karma-coverage-istanbul-reporter'),
+      require('karma-nightmare'),
       require('@angular/cli/plugins/karma')
     ],
     client:{
@@ -38,7 +39,7 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['Chrome'],
+    browsers: ['Nightmare'],
     singleRun: false
   });
 };

--- a/package.json
+++ b/package.json
@@ -50,9 +50,10 @@
     "karma": "~1.4.1",
     "karma-chrome-launcher": "~2.0.0",
     "karma-cli": "~1.0.1",
+    "karma-coverage-istanbul-reporter": "^0.2.0",
     "karma-jasmine": "~1.1.0",
     "karma-jasmine-html-reporter": "^0.2.2",
-    "karma-coverage-istanbul-reporter": "^0.2.0",
+    "karma-nightmare": "^0.4.9",
     "protractor": "~5.1.0",
     "ts-node": "~2.0.0",
     "tslint": "~4.5.0"


### PR DESCRIPTION
Use karma-nightmare to speed unit tests

1) npm install karma-nightmare --save-dev
2) In karma.conf.js use Nightmare browser instead of Chrome
```
plugins: [
  ...
  require('karma-nightmare')
],
...
browsers: ['Nightmare'],
```
3) Configure Travis.
Nightmare.js is not a trully headless browser. It still needs a user interface, use xvfb (X Virtual Framebuffer) on linux to imitate one.

.travis.yml
```
...
before_install:
 - export DISPLAY=:99.0
 - sh -e /etc/init.d/xvfb start
 - sleep 3 # give xvfb some time to start
```

Before I had travis configured for xvfb and chrome, at least know I do not need to install and configure chrome.
```
...
before_install:
 - export CHROME_BIN=/usr/bin/google-chrome
 - export DISPLAY=:99.0
 - sh -e /etc/init.d/xvfb start
 - sudo apt-get update
 - sudo apt-get install -y libappindicator1 fonts-liberation
 - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
 - sudo dpkg -i google-chrome*.deb
```

Docs:
https://github.com/el-davo/angular-redux-saga/pull/1/files
https://docs.travis-ci.com/user/gui-and-headless-browsers/
https://github.com/segmentio/nightmare/issues/744

